### PR TITLE
fix: improve uns-1 color mappings

### DIFF
--- a/src/include/products/fmc/profiles/c525-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/c525-fmc-profile.cpp
@@ -168,7 +168,20 @@ const std::unordered_map<FMCKey, const FMCButtonDef *> &C525FMCProfile::buttonKe
 }
 
 const std::map<char, FMCTextColor> &C525FMCProfile::colorMap() const {
-    return UNS1Decode::colorMap();
+    static const std::map<char, FMCTextColor> colMap = {
+        {0x00, FMCTextColor::COLOR_WHITE},
+        {0x01, FMCTextColor::COLOR_WHITE},
+        {0x02, FMCTextColor::COLOR_CYAN},
+        {0x03, FMCTextColor::COLOR_YELLOW},
+        {0x04, FMCTextColor::COLOR_AMBER},
+        {0x05, FMCTextColor::COLOR_MAGENTA},
+        {0x06, FMCTextColor::COLOR_CYAN},
+        {0x07, FMCTextColor::COLOR_YELLOW},
+        {0x09, FMCTextColor::COLOR_WHITE},
+        {0x0B, FMCTextColor::COLOR_GREEN},
+        {0x40, FMCTextColor::withBackgroundColor(FMCTextColor::COLOR_BLACK, FMCTextColor::COLOR_WHITE)},
+    };
+    return colMap;
 }
 
 void C525FMCProfile::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) {

--- a/src/include/products/fmc/profiles/c525-fmc-profile.h
+++ b/src/include/products/fmc/profiles/c525-fmc-profile.h
@@ -4,10 +4,11 @@
 #include "fmc-aircraft-profile.h"
 
 // TorqueSim Citation CJ (C525): a single-pilot aircraft with one CDU/FMS on the
-// stock Universal Avionics UNS-1 "uns1/cdu1" / "uns1/fms1" dataref namespace. The
-// UNS-1 screen decoding (symbol tables, page decode, glyph and colour mapping) is
-// shared via UNS1Decode; the button map, eligibility and backlight wiring are
-// specific to this airframe.
+// Universal Avionics UNS-1 "uns1/cdu1" / "uns1/fms1" dataref namespace. The UNS-1
+// screen decoding (symbol tables, page decode, glyph mapping) is shared via
+// UNS1Decode, but the style-byte colour table is this aircraft's own (its
+// nibble->colour encoding differs from the FJS732 and Q4XP). The button map,
+// eligibility and backlight wiring are specific to this airframe.
 class C525FMCProfile : public FMCAircraftProfile {
     public:
         C525FMCProfile(ProductFMC *product);

--- a/src/include/products/fmc/profiles/fjs732-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/fjs732-fmc-profile.cpp
@@ -168,7 +168,20 @@ const std::unordered_map<FMCKey, const FMCButtonDef *> &FJS732FMCProfile::button
 }
 
 const std::map<char, FMCTextColor> &FJS732FMCProfile::colorMap() const {
-    return UNS1Decode::colorMap();
+    static const std::map<char, FMCTextColor> colMap = {
+        {0x00, FMCTextColor::COLOR_WHITE},
+        {0x01, FMCTextColor::COLOR_GREEN},
+        {0x02, FMCTextColor::COLOR_AMBER},
+        {0x03, FMCTextColor::COLOR_YELLOW},
+        {0x04, FMCTextColor::COLOR_CYAN},
+        {0x05, FMCTextColor::COLOR_MAGENTA},
+        {0x06, FMCTextColor::COLOR_GREEN},
+        {0x07, FMCTextColor::COLOR_RED},
+        {0x09, FMCTextColor::COLOR_GREY},
+        {0x0B, FMCTextColor::COLOR_GREEN},
+        {0x40, FMCTextColor::withBackgroundColor(FMCTextColor::COLOR_BLACK, FMCTextColor::COLOR_WHITE)},
+    };
+    return colMap;
 }
 
 void FJS732FMCProfile::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) {

--- a/src/include/products/fmc/profiles/fjs732-fmc-profile.h
+++ b/src/include/products/fmc/profiles/fjs732-fmc-profile.h
@@ -3,11 +3,12 @@
 
 #include "fmc-aircraft-profile.h"
 
-// FlyJSim 737-200: a single CDU/FMS (no captain/FO split) on the stock Universal
+// FlyJSim 737-200: a single CDU/FMS (no captain/FO split) on the Universal
 // Avionics UNS-1 "uns1/cdu1" / "uns1/fms1" dataref namespace. The UNS-1 screen
-// decoding (symbol tables, page decode, glyph and colour mapping) is shared via
-// UNS1Decode; the button map, eligibility and backlight wiring are specific to
-// this airframe.
+// decoding (symbol tables, page decode, glyph mapping) is shared via UNS1Decode,
+// but the style-byte colour table is this aircraft's own (its nibble->colour
+// encoding differs from the CJ525 and Q4XP). The button map, eligibility and
+// backlight wiring are specific to this airframe.
 class FJS732FMCProfile : public FMCAircraftProfile {
     public:
         FJS732FMCProfile(ProductFMC *product);

--- a/src/include/products/fmc/profiles/q4xp-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/q4xp-fmc-profile.cpp
@@ -185,7 +185,19 @@ const std::unordered_map<FMCKey, const FMCButtonDef *> &Q4XPFMCProfile::buttonKe
 }
 
 const std::map<char, FMCTextColor> &Q4XPFMCProfile::colorMap() const {
-    return UNS1Decode::colorMap();
+    static const std::map<char, FMCTextColor> colMap = {
+        {0x00, FMCTextColor::COLOR_WHITE},
+        {0x01, FMCTextColor::COLOR_WHITE},
+        {0x02, FMCTextColor::COLOR_GREEN},
+        {0x03, FMCTextColor::COLOR_YELLOW},
+        {0x04, FMCTextColor::COLOR_GREEN},
+        {0x05, FMCTextColor::COLOR_MAGENTA},
+        {0x06, FMCTextColor::COLOR_GREEN},
+        {0x07, FMCTextColor::COLOR_CYAN},
+        {0x0B, FMCTextColor::COLOR_GREEN},
+        {0x40, FMCTextColor::withBackgroundColor(FMCTextColor::COLOR_BLACK, FMCTextColor::COLOR_WHITE)},
+    };
+    return colMap;
 }
 
 void Q4XPFMCProfile::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) {

--- a/src/include/products/fmc/uns1-decode.cpp
+++ b/src/include/products/fmc/uns1-decode.cpp
@@ -133,19 +133,3 @@ void UNS1Decode::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character) {
             break;
     }
 }
-
-const std::map<char, FMCTextColor> &UNS1Decode::colorMap() {
-    static const std::map<char, FMCTextColor> colMap = {
-        {0x00, FMCTextColor::COLOR_WHITE},
-        {0x01, FMCTextColor::COLOR_WHITE},
-        {0x02, FMCTextColor::COLOR_GREEN},
-        {0x03, FMCTextColor::COLOR_YELLOW},
-        {0x04, FMCTextColor::COLOR_GREEN},
-        {0x05, FMCTextColor::COLOR_MAGENTA},
-        {0x06, FMCTextColor::COLOR_GREEN},
-        {0x07, FMCTextColor::COLOR_CYAN},
-        {0x0B, FMCTextColor::COLOR_GREEN},
-        {0x40, FMCTextColor::withBackgroundColor(FMCTextColor::COLOR_BLACK, FMCTextColor::COLOR_WHITE)},  // inverted (ACCEPT)
-    };
-    return colMap;
-}

--- a/src/include/products/fmc/uns1-decode.h
+++ b/src/include/products/fmc/uns1-decode.h
@@ -13,9 +13,11 @@ class ProductFMC;
 // Shared decoding for aircraft that expose a Universal Avionics UNS-1 style CDU
 // (the "text_line_N" / "style_line_N" string + style-byte dataref pairs). These
 // helpers hold the parts that are identical across every UNS-1 integration — the
-// symbol tables, the per-line screen decode, the special-character glyph mapping,
-// and the style-byte colour table — so each aircraft profile stays standalone and
-// only supplies its own dataref namespace.
+// symbol tables, the per-line screen decode, and the special-character glyph
+// mapping — so each aircraft profile stays standalone and only supplies its own
+// dataref namespace. The style-byte colour table is NOT shared: each aircraft's
+// UNS-1 build uses a different nibble->colour encoding, so every profile provides
+// its own colorMap().
 namespace UNS1Decode {
     // Decode `lineCount` text/style dataref pairs under `displayPrefix`
     // (e.g. "FJS/Q4XP/cdu1" or "uns1/cdu1") into `page`, resolving unicode and
@@ -26,9 +28,6 @@ namespace UNS1Decode {
     // Translate a decoded placeholder byte into the UTF-8 glyph bytes the display
     // expects, appending to `buffer`.
     void mapCharacter(std::vector<uint8_t> *buffer, uint8_t character);
-
-    // Style-byte (low nibble, or 0x40 for inverted) -> text colour table.
-    const std::map<char, FMCTextColor> &colorMap();
 }
 
 #endif // UNS1_DECODE_H


### PR DESCRIPTION
The color mappings for each UNS-1 variant are slightly different. These custom color maps should make them match as close to possible with the currently available color set. 