### PR TITLE
Perf: Strip release binaries, archive split debug symbols.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,14 @@ SET(CMAKE_CXX_STANDARD 23)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 # This is the distribution path: build_platforms.sh drives it for all three platforms, so it optimises.
 # Debug builds come from the Xcode project instead, with its own settings, and nothing here caters to them.
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
-SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+# -g1 is intentional here too: build_platforms.sh splits the DWARF/debug info
+# out into build/symbols/ and strips the shipped .xpl afterwards, so crashes
+# reported against a release build can still be symbolicated (function + line)
+# from the archive. Plain -g2 (what -g implies) was tried and rejected: across
+# this codebase's heavy template/header use it produced 150+MB of per-variable
+# location debug info per platform for no symbolication benefit -g1 lacks.
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -g1")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -g1")
 PROJECT(winctrl C CXX)
 
 IF(APPLE)

--- a/build_platforms.sh
+++ b/build_platforms.sh
@@ -49,6 +49,17 @@ fi
 RELEASE_TAG=$VERSION-$XPLANE_VERSION
 SYMBOLS_DIR="build/symbols/$RELEASE_TAG"
 
+# Catches a no-op rebuild re-stripping an already-stripped $BIN, which yields empty debug info.
+MIN_DEBUG_KB=512
+check_debug_size() {
+    SIZE_KB=$(du -sk "$1" 2>/dev/null | awk '{print $1}')
+    if [ -z "$SIZE_KB" ] || [ "$SIZE_KB" -lt "$MIN_DEBUG_KB" ]; then
+        echo "\033[1;31mERROR: debug info at $1 is only ${SIZE_KB:-0}KB - it looks empty.\033[0m"
+        echo "This usually means $BIN was already stripped by a previous run and make didn't relink it this time. Do a clean build and try again."
+        exit 1
+    fi
+}
+
 echo "Building with SDK version $SDK_VERSION\n"
 
 echo "Clean build directory? (y/n) [default: n]:"
@@ -95,24 +106,25 @@ for platform in $PLATFORMS; do
     fi
 
     if [ $? -eq 0 ]; then
-        # Split debug info out before stripping so release .xpl files stay
-        # small, but crashes from a shipped build can still be symbolicated
-        # from the matching archive in build/symbols/.
+        # Archive debug info to build/symbols/ before stripping the shipped .xpl.
         mkdir -p "$SYMBOLS_DIR/${platform}_x64"
         case $platform in
             mac)
                 dsymutil "$BIN" -o "$BIN.dSYM"
+                check_debug_size "$BIN.dSYM"
                 strip -x "$BIN"
                 cp -r "$BIN.dSYM" "$SYMBOLS_DIR/${platform}_x64/"
                 ;;
             win)
                 x86_64-w64-mingw32-objcopy --only-keep-debug "$BIN" "$BIN.debug"
+                check_debug_size "$BIN.debug"
                 x86_64-w64-mingw32-strip -s "$BIN"
                 x86_64-w64-mingw32-objcopy --add-gnu-debuglink="$BIN.debug" "$BIN"
                 cp "$BIN.debug" "$SYMBOLS_DIR/${platform}_x64/"
                 ;;
             lin)
-                # objcopy/strip already ran inside the docker container above.
+                # objcopy/strip already ran in the docker container above.
+                check_debug_size "$BIN.debug"
                 cp "$BIN.debug" "$SYMBOLS_DIR/${platform}_x64/"
                 ;;
         esac

--- a/build_platforms.sh
+++ b/build_platforms.sh
@@ -41,6 +41,14 @@ fi
 SDK_VERSION=$(grep "#define kXPLM_Version" SDK/CHeaders/XPLM/XPLMDefs.h | awk '{print $3}' | tr -d '()')
 JOBS=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
 
+if [ $SDK_VERSION -lt 400 ]; then
+    XPLANE_VERSION=XP11
+else
+    XPLANE_VERSION=XP12
+fi
+RELEASE_TAG=$VERSION-$XPLANE_VERSION
+SYMBOLS_DIR="build/symbols/$RELEASE_TAG"
+
 echo "Building with SDK version $SDK_VERSION\n"
 
 echo "Clean build directory? (y/n) [default: n]:"
@@ -66,26 +74,52 @@ fi
 
 for platform in $PLATFORMS; do
     echo "Building $platform..."
+    BIN="build/$platform/${platform}_x64/${PROJECT_NAME}.xpl"
     if [ $platform = "lin" ]; then
         docker build -t xplane-build:jammy-gcc13 -f ./docker/Dockerfile.linux . && \
         docker run --user $(id -u):$(id -g) --rm -v $(pwd):/src -w /src xplane-build:jammy-gcc13 bash -c "\
         cmake -DCMAKE_CXX_FLAGS='-march=x86-64' -DCMAKE_TOOLCHAIN_FILE=toolchain-$platform.cmake -DSDK_VERSION=$SDK_VERSION -Bbuild/$platform -H. && \
         make -C build/$platform -j\$(nproc) && \
-        if objdump -T build/$platform/${platform}_x64/${PROJECT_NAME}.xpl | grep -q '__isoc23_'; then \
+        if objdump -T $BIN | grep -q '__isoc23_'; then \
             echo 'ERROR: this build links post-glibc-2.36 symbols:'; \
-            objdump -T build/$platform/${platform}_x64/${PROJECT_NAME}.xpl | grep -o '__isoc23_[a-z]*' | sort -u; \
+            objdump -T $BIN | grep -o '__isoc23_[a-z]*' | sort -u; \
             echo 'The Linux image base is too new; the plugin will not load on older distros. See docker/Dockerfile.linux.'; \
             exit 1; \
-        fi"
+        fi && \
+        objcopy --only-keep-debug $BIN $BIN.debug && \
+        strip --strip-debug --strip-unneeded $BIN && \
+        objcopy --add-gnu-debuglink=$BIN.debug $BIN"
     else
         cmake -DCMAKE_TOOLCHAIN_FILE=toolchain-$platform.cmake -DSDK_VERSION=$SDK_VERSION -Bbuild/$platform -H.
         make -C build/$platform -j$JOBS
     fi
 
     if [ $? -eq 0 ]; then
+        # Split debug info out before stripping so release .xpl files stay
+        # small, but crashes from a shipped build can still be symbolicated
+        # from the matching archive in build/symbols/.
+        mkdir -p "$SYMBOLS_DIR/${platform}_x64"
+        case $platform in
+            mac)
+                dsymutil "$BIN" -o "$BIN.dSYM"
+                strip -x "$BIN"
+                cp -r "$BIN.dSYM" "$SYMBOLS_DIR/${platform}_x64/"
+                ;;
+            win)
+                x86_64-w64-mingw32-objcopy --only-keep-debug "$BIN" "$BIN.debug"
+                x86_64-w64-mingw32-strip -s "$BIN"
+                x86_64-w64-mingw32-objcopy --add-gnu-debuglink="$BIN.debug" "$BIN"
+                cp "$BIN.debug" "$SYMBOLS_DIR/${platform}_x64/"
+                ;;
+            lin)
+                # objcopy/strip already ran inside the docker container above.
+                cp "$BIN.debug" "$SYMBOLS_DIR/${platform}_x64/"
+                ;;
+        esac
+
         echo "\n\n"
-        echo "\033[1;32m$platform build succeeded.\033[0m\nProduct: build/$platform/${platform}_x64/${PROJECT_NAME}.xpl"
-        file build/$platform/${platform}_x64/${PROJECT_NAME}.xpl
+        echo "\033[1;32m$platform build succeeded.\033[0m\nProduct: $BIN"
+        file $BIN
         sleep 3
     else
         echo "\033[1;31m$platform build failed.\033[0m"
@@ -117,13 +151,7 @@ fi
 cd build
 mv dist $PROJECT_NAME
 
-if [ $SDK_VERSION -lt 400 ]; then
-    XPLANE_VERSION=XP11
-else
-    XPLANE_VERSION=XP12
-fi
-
-VERSION=$VERSION-$XPLANE_VERSION
+VERSION=$RELEASE_TAG
 
 rm -f $PROJECT_NAME-$VERSION.zip
 zip -rq $PROJECT_NAME-$VERSION.zip $PROJECT_NAME -x "*/.DS_Store" -x "*/__MACOSX/*"
@@ -132,6 +160,7 @@ mv $PROJECT_NAME dist
 cd ..
 
 echo "Bundle created. Distribution: build/dist/$PROJECT_NAME-$VERSION.zip"
+echo "Debug symbols archived: $SYMBOLS_DIR (keep this if you need to symbolicate crashes from this release)"
 
 # Upload to Google Drive if requested and gdrive is available
 if [ "$UPLOAD_TO_DRIVE" = "y" ] && command -v gdrive &> /dev/null; then


### PR DESCRIPTION
Debug info and unstripped symbols were bloating shipped .xpl files (Windows was 57% DWARF). 

Split debug info out per-platform before stripping, archived under build/symbols/ for future crash lookups.

| Platform | Before | After | Reduction |
|-------------------|-------:|------:|----------:|
| Windows           | 22.4 MB | 5.8 MB | 74% |
| macOS (Universal) | 8.5 MB  | 6.0 MB | 30% |
| Linux             | 4.5 MB  | 4.0 MB | 11% |