### PR TITLE
Perf: Skip redundant USB redraws on FMC when the CDU page is unchanged.

### DIFF
--- a/src/include/products/fmc/product-fmc.cpp
+++ b/src/include/products/fmc/product-fmc.cpp
@@ -35,6 +35,7 @@
 ProductFMC::ProductFMC(HIDDeviceHandle hidDevice, uint16_t vendorId, uint16_t productId, std::string vendorName, std::string productName, FMCHardwareType hardwareType, FMCDeviceVariant variant, unsigned char identifierByte) : USBDevice(hidDevice, vendorId, productId, vendorName, productName), hardwareType(hardwareType), identifierByte(identifierByte), deviceVariant(variant) {
     profile = nullptr;
     page = std::vector<std::vector<char>>(ProductFMC::PageLines, std::vector<char>(ProductFMC::PageBytesPerLine, ' '));
+    lastDrawnPage = page;
     lastUpdateCycle = 0;
     lastButtonStateLo = 0;
     lastButtonStateHi = 0;
@@ -409,7 +410,12 @@ void ProductFMC::updatePage(bool forceUpdate) {
     if (shouldUpdate) {
         profile->updatePage(page);
         lastUpdateCycle = XPLMGetCycleNumber();
-        draw();
+
+        // Skip the USB transmission if nothing actually changed on screen.
+        if (forceUpdate || page != lastDrawnPage) {
+            draw();
+            lastDrawnPage = page;
+        }
     }
 }
 
@@ -499,6 +505,7 @@ void ProductFMC::writeLineToPage(std::vector<std::vector<char>> &page, int line,
 
 void ProductFMC::clearDisplay() {
     page = std::vector<std::vector<char>>(ProductFMC::PageLines, std::vector<char>(ProductFMC::PageBytesPerLine, ' '));
+    lastDrawnPage = page;
 
     std::vector<uint8_t> blankLine = {};
     blankLine.push_back(0xf2);

--- a/src/include/products/fmc/product-fmc.h
+++ b/src/include/products/fmc/product-fmc.h
@@ -13,6 +13,8 @@ class ProductFMC : public USBDevice {
     private:
         FMCAircraftProfile *profile;
         std::vector<std::vector<char>> page;
+        // What was last actually sent to the hardware.
+        std::vector<std::vector<char>> lastDrawnPage;
         int lastUpdateCycle;
         int displayUpdateFrameCounter = 0;
         std::set<int> pressedButtonIndices;


### PR DESCRIPTION
Any of a profile's tracked datarefs (Toliss alone watches ~130) could trigger a full page rebuild and retransmission even when none of them affect what's actually shown on screen.