### PR TITLE
common 7-segment display helpers

### DIFF
--- a/src/include/products/agp/product-agp.cpp
+++ b/src/include/products/agp/product-agp.cpp
@@ -171,57 +171,6 @@ void ProductAGP::setLedBrightness(AGPLed led, uint8_t brightness) {
     writeData({0x02, ProductAGP::IdentifierByte, 0xBB, 0x00, 0x00, 0x03, 0x49, static_cast<uint8_t>(led), brightness, 0x00, 0x00, 0x00, 0x00, 0x00});
 }
 
-void ProductAGP::parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset) {
-    std::string digits;
-    uint16_t localColonMask = 0;
-
-    for (size_t i = 0; i < text.length(); ++i) {
-        char c = text[i];
-        if (c == ':' || c == '.') {
-            if (!digits.empty()) {
-                if (expectedLength >= 6) {
-                    // Standard: Enable bit for digit before (Left) and digit after (Right)
-
-                    if (c == ':') {
-                        localColonMask |= (1 << (digits.length() - 1)); // Upper Dot
-                    }
-
-                    localColonMask |= (1 << digits.length()); // Lower Dot
-                } else {
-                    // 4-Digit Displays: Enable bit for digit after (Right) and next digit (Right + 1)
-                    // The digit 'digits.length()' is the one we are about to add next.
-
-                    if (c == ':') {
-                        localColonMask |= (1 << digits.length()); // Upper Dot
-                    }
-
-                    localColonMask |= (1 << (digits.length() + 1)); // Lower Dot
-                }
-            }
-        } else {
-            digits += c;
-        }
-    }
-
-    // Calculate padding amount before modifying digits
-    int paddingAmount = 0;
-    if (digits.length() < static_cast<size_t>(expectedLength)) {
-        paddingAmount = expectedLength - static_cast<int>(digits.length());
-    }
-
-    // Shift colon positions by padding amount and add to global mask with offset
-    colonMask |= (localColonMask << paddingAmount) << digitOffset;
-
-    // Pad or truncate to expected length
-    while (digits.length() < static_cast<size_t>(expectedLength)) {
-        digits = ' ' + digits; // Left-pad with spaces
-    }
-    if (digits.length() > static_cast<size_t>(expectedLength)) {
-        digits = digits.substr(digits.length() - expectedLength);
-    }
-    outDigits += digits;
-}
-
 void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTime, const std::string &elapsedTime) {
     std::vector<uint8_t> packet = {
         0xF0, 0x00, packetNumber, 0x35, ProductAGP::IdentifierByte,
@@ -229,35 +178,17 @@ void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTim
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[8] = {25, 29, 33, 37, 41, 45, 49, 53};
+    const int segmentRowOffsets[7] = {25, 29, 33, 37, 41, 45, 49};
+    const int colonRowOffset = 53;
 
     std::string allDigits;
     uint16_t colonMask = 0;
 
-    parseSegment(chrono, 4, allDigits, colonMask, 0);
-    parseSegment(utcTime, 6, allDigits, colonMask, 4);
-    parseSegment(elapsedTime, 4, allDigits, colonMask, 10);
+    SegmentDisplay::parseSegmentText(chrono, 4, allDigits, colonMask, 0, SegmentDisplay::DotPlacement::DualDot);
+    SegmentDisplay::parseSegmentText(utcTime, 6, allDigits, colonMask, 4, SegmentDisplay::DotPlacement::DualDot);
+    SegmentDisplay::parseSegmentText(elapsedTime, 4, allDigits, colonMask, 10, SegmentDisplay::DotPlacement::DualDot);
 
-    for (int digitIndex = 0; digitIndex < 14; ++digitIndex) {
-        char c = allDigits[digitIndex];
-        uint8_t charMask = SegmentDisplay::getSegmentMask(c);
-
-        for (int segIndex = 0; segIndex < 7; ++segIndex) {
-            if (charMask & (1 << segIndex)) {
-                int byteOffset = rowOffsets[segIndex] + (digitIndex / 8);
-
-                int bitPos = digitIndex % 8;
-
-                packet[byteOffset] |= (1 << bitPos);
-            }
-        }
-
-        if (colonMask & (1 << digitIndex)) {
-            int byteOffset = rowOffsets[7] + (digitIndex / 8);
-            int bitPos = digitIndex % 8;
-            packet[byteOffset] |= (1 << bitPos);
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, allDigits, colonMask, segmentRowOffsets, 7, colonRowOffset);
 
     writeData(packet);
 

--- a/src/include/products/agp/product-agp.h
+++ b/src/include/products/agp/product-agp.h
@@ -48,7 +48,6 @@ class ProductAGP : public USBDevice {
         uint8_t packetNumber = 1;
 
         void setProfileForCurrentAircraft();
-        void parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset);
 
     public:
         ProductAGP(HIDDeviceHandle hidDevice, uint16_t vendorId, uint16_t productId, std::string vendorName, std::string productName);

--- a/src/include/products/rmp/product-rmp.cpp
+++ b/src/include/products/rmp/product-rmp.cpp
@@ -255,41 +255,6 @@ void ProductRMP::setLedBrightness(RMPLed led, uint8_t brightness) {
     writeData({0x02, ProductRMP::IdentifierByte, 0xBB, 0x00, 0x00, 0x03, 0x49, static_cast<uint8_t>(led), brightness, 0x00, 0x00, 0x00, 0x00, 0x00});
 }
 
-void ProductRMP::parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset) {
-    std::string digits;
-    uint16_t localColonMask = 0;
-
-    for (size_t i = 0; i < text.length(); ++i) {
-        char c = text[i];
-        if (c == '.' && !digits.empty()) {
-            localColonMask |= (1 << (digits.length() - 1));
-        } else if (c == '/') {
-            /* ToLiss datarefs use a C/course format for backup nav */
-            digits += '-';
-        } else {
-            digits += c;
-        }
-    }
-
-    // Calculate padding amount before modifying digits
-    int paddingAmount = 0;
-    if (digits.length() < static_cast<size_t>(expectedLength)) {
-        paddingAmount = expectedLength - static_cast<int>(digits.length());
-    }
-
-    // Shift colon positions by padding amount and add to global mask with offset
-    colonMask |= (localColonMask << paddingAmount) << digitOffset;
-
-    // Pad or truncate to expected length
-    while (digits.length() < static_cast<size_t>(expectedLength)) {
-        digits = ' ' + digits; // Left-pad with spaces
-    }
-    if (digits.length() > static_cast<size_t>(expectedLength)) {
-        digits = digits.substr(digits.length() - expectedLength);
-    }
-    outDigits += digits;
-}
-
 void ProductRMP::setDisplayText(const std::string &active, const std::string &stby) {
     if (active == cachedActiveDisplay && stby == cachedStbyDisplay) {
         return;
@@ -309,8 +274,9 @@ void ProductRMP::setDisplayText(const std::string &active, const std::string &st
     uint16_t colonMask = 0;
 
     /* Standby is first, Active is second */
-    parseSegment(stby, 6, allDigits, colonMask, 0);
-    parseSegment(active, 6, allDigits, colonMask, 6);
+    /* ToLiss datarefs use a C/course format for backup nav, hence the '/' -> '-' replacement */
+    SegmentDisplay::parseSegmentText(stby, 6, allDigits, colonMask, 0, SegmentDisplay::DotPlacement::PrecedingDigit, '-');
+    SegmentDisplay::parseSegmentText(active, 6, allDigits, colonMask, 6, SegmentDisplay::DotPlacement::PrecedingDigit, '-');
 
     for (int digitIndex = 0; digitIndex < 12; ++digitIndex) {
         char c = allDigits[digitIndex];

--- a/src/include/products/rmp/product-rmp.h
+++ b/src/include/products/rmp/product-rmp.h
@@ -53,7 +53,6 @@ class ProductRMP : public USBDevice {
         std::string cachedStbyDisplay;
 
         void setProfileForCurrentAircraft();
-        void parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset);
         const char *positionName() const;
         std::string variantPreferenceKey() const;
 

--- a/src/include/products/tcas/product-tcas.cpp
+++ b/src/include/products/tcas/product-tcas.cpp
@@ -175,24 +175,9 @@ void ProductTCAS::setLCDText(const std::string &squawkCode) {
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[7] = {37, 33, 29, 25, 49, 45, 41};
+    const int segmentRowOffsets[7] = {37, 33, 29, 25, 49, 45, 41};
 
-    std::string allDigits = squawkCode;
-
-    for (int digitIndex = 0; digitIndex < 4; ++digitIndex) {
-        if (digitIndex < static_cast<int>(allDigits.length())) {
-            char c = allDigits[digitIndex];
-            uint8_t charMask = SegmentDisplay::getSegmentMask(c);
-
-            for (int segIndex = 0; segIndex < 7; ++segIndex) {
-                if (charMask & (1 << segIndex)) {
-                    int byteOffset = rowOffsets[segIndex] + (digitIndex / 8);
-                    int bitPos = digitIndex % 8;
-                    packet[byteOffset] |= (1 << bitPos);
-                }
-            }
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, squawkCode, 0, segmentRowOffsets, 7, -1);
 
     writeData(packet);
 

--- a/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
+++ b/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
@@ -201,15 +201,14 @@ void ProductUrsaMinorThrottle::setVibration(uint8_t vibration, bool leftSide, bo
 }
 
 void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
-    bool unknownFlag = false;
     std::vector<uint8_t> packet = {
         0xF0, 0x00, packetNumber, 0x35, ProductUrsaMinorThrottle::PACIdentifierByte, 0xB9,
         0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[9] = {53, 49, 45, 41, 37, 33, 29, 25, 57};
-    const int digitBits[4] = {0, 1, 2, 3};
+    const int segmentRowOffsets[7] = {53, 49, 45, 41, 37, 33, 29};
+    const int dotRowOffset = 25;
 
     std::string charsOnly = "";
     uint8_t dotsMask = 0;
@@ -247,36 +246,7 @@ void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
         charsOnly += " ";
     }
 
-    for (int i = 0; i < 4; ++i) {
-        char c = charsOnly[i];
-        int targetBit = digitBits[i];
-
-        uint16_t mask = SegmentDisplay::getSegmentMask(c);
-
-        // Apply the unknown flag ONLY to the first character (L or R)
-        if (i == 0 && unknownFlag) {
-            mask |= 0x100; // Set Bit 8
-        }
-
-        for (int segIndex = 0; segIndex < 9; ++segIndex) {
-            bool turnOn = false;
-
-            if (segIndex == 7) {
-                if ((dotsMask >> i) & 1) {
-                    turnOn = true;
-                }
-            } else {
-                if ((mask >> segIndex) & 1) {
-                    turnOn = true;
-                }
-            }
-
-            if (turnOn) {
-                int byteOffset = rowOffsets[segIndex];
-                packet[byteOffset] |= (1 << targetBit);
-            }
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, charsOnly, dotsMask, segmentRowOffsets, 7, dotRowOffset);
 
     writeData(packet);
 

--- a/src/include/utils/segment-display.cpp
+++ b/src/include/utils/segment-display.cpp
@@ -401,4 +401,88 @@ namespace SegmentDisplay {
 
         return result;
     }
+
+    void parseSegmentText(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &dotMask, int digitOffset, DotPlacement dotPlacement, char slashReplacement) {
+        std::string digits;
+        uint16_t localDotMask = 0;
+
+        for (char c : text) {
+            const bool isSeparator = (c == '.') || (c == ':' && dotPlacement == DotPlacement::DualDot);
+
+            if (isSeparator && digits.empty() && dotPlacement == DotPlacement::PrecedingDigit) {
+                // No preceding digit to attach the dot to; keep the character as-is
+                digits += c;
+                continue;
+            }
+
+            if (isSeparator) {
+                if (digits.empty()) {
+                    continue;
+                }
+
+                switch (dotPlacement) {
+                    case DotPlacement::PrecedingDigit:
+                        localDotMask |= (1 << (digits.length() - 1));
+                        break;
+                    case DotPlacement::DualDot:
+                        if (expectedLength >= 6) {
+                            // Standard: dot bits for digit before (Left) and digit after (Right)
+                            if (c == ':') {
+                                localDotMask |= (1 << (digits.length() - 1)); // Upper Dot
+                            }
+                            localDotMask |= (1 << digits.length()); // Lower Dot
+                        } else {
+                            // 4-Digit Displays: dot bits for digit after (Right) and next digit (Right + 1)
+                            if (c == ':') {
+                                localDotMask |= (1 << digits.length()); // Upper Dot
+                            }
+                            localDotMask |= (1 << (digits.length() + 1)); // Lower Dot
+                        }
+                        break;
+                }
+            } else if (slashReplacement != '\0' && c == '/') {
+                digits += slashReplacement;
+            } else {
+                digits += c;
+            }
+        }
+
+        // Calculate padding amount before modifying digits
+        int paddingAmount = 0;
+        if (digits.length() < static_cast<size_t>(expectedLength)) {
+            paddingAmount = expectedLength - static_cast<int>(digits.length());
+        }
+
+        // Shift dot positions by padding amount and add to global mask with offset
+        dotMask |= (localDotMask << paddingAmount) << digitOffset;
+
+        // Pad or truncate to expected length
+        while (digits.length() < static_cast<size_t>(expectedLength)) {
+            digits = ' ' + digits; // Left-pad with spaces
+        }
+        if (digits.length() > static_cast<size_t>(expectedLength)) {
+            digits = digits.substr(digits.length() - expectedLength);
+        }
+        outDigits += digits;
+    }
+
+    void encodeBitplane(std::vector<uint8_t> &packet, const std::string &digits, uint16_t dotMask, const int *segmentRowOffsets, int numSegmentRows, int dotRowOffset) {
+        for (int digitIndex = 0; digitIndex < static_cast<int>(digits.length()); ++digitIndex) {
+            uint8_t charMask = getSegmentMask(digits[digitIndex]);
+
+            for (int segIndex = 0; segIndex < numSegmentRows; ++segIndex) {
+                if (charMask & (1 << segIndex)) {
+                    int byteOffset = segmentRowOffsets[segIndex] + (digitIndex / 8);
+                    int bitPos = digitIndex % 8;
+                    packet[byteOffset] |= (1 << bitPos);
+                }
+            }
+
+            if (dotRowOffset >= 0 && (dotMask & (1 << digitIndex))) {
+                int byteOffset = dotRowOffset + (digitIndex / 8);
+                int bitPos = digitIndex % 8;
+                packet[byteOffset] |= (1 << bitPos);
+            }
+        }
+    }
 }

--- a/src/include/utils/segment-display.h
+++ b/src/include/utils/segment-display.h
@@ -30,6 +30,27 @@ namespace SegmentDisplay {
     // AGP 2-byte per digit encoding (little-endian format)
     std::vector<uint8_t> encodeStringAGP(int numSegments, const std::string &str);
 
+    // Dot/colon placement scheme used when parsing display text
+    enum class DotPlacement {
+        // Dot attaches to the digit right before the separator (e.g. RMP frequency decimal point)
+        PrecedingDigit,
+        // Colon renders as two dots around the separator position (AGP clock displays)
+        DualDot,
+    };
+
+    // Parse display text into fixed-width digits plus a dot-position bitmask.
+    // Separators ('.' and ':') are removed from the digit stream and recorded as dot bits.
+    // Digits are right-aligned (left-padded with spaces) to expectedLength and appended to outDigits.
+    // The local dot bits are shifted by the padding amount and digitOffset before being OR-ed into dotMask.
+    // slashReplacement, when not '\0', substitutes '/' characters in the digit stream.
+    void parseSegmentText(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &dotMask, int digitOffset, DotPlacement dotPlacement, char slashReplacement = '\0');
+
+    // Encode digits (and optional dots) into a packet using bitplane row offsets.
+    // segmentRowOffsets[seg] gives the packet byte offset holding segment bit 'seg' for digit 0;
+    // digits beyond the first 8 continue into subsequent bytes (offset + digit / 8, bit digit % 8).
+    // dotRowOffset is the base packet byte offset for dot/colon bits; pass -1 to disable dots.
+    void encodeBitplane(std::vector<uint8_t> &packet, const std::string &digits, uint16_t dotMask, const int *segmentRowOffsets, int numSegmentRows, int dotRowOffset);
+
 }
 
 #endif


### PR DESCRIPTION
What: 
Extract duplicated 7-segment display logic (AGP, TCAS, RMP, URSA Minor Throttle) into two shared functions in the SegmentDisplay namespace: parseSegmentText() and encodeBitplane().

Why: 
The same parse/encode code was copy-pasted across multiple products. Centralizing it removes about 200 lines of duplication and makes future display changes easier to maintain.