### PR TITLE
Extract shared 0xF0 display frame builder for all LCD products

### DIFF
--- a/WINCTRL.xcodeproj/project.pbxproj
+++ b/WINCTRL.xcodeproj/project.pbxproj
@@ -460,6 +460,7 @@
 		F6A77E702ED3514600061D03 /* product-agp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "product-agp.cpp"; sourceTree = "<group>"; };
 		F6A77E772ED3620600061D03 /* segment-display.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "segment-display.h"; sourceTree = "<group>"; };
 		F6A77E782ED3620600061D03 /* segment-display.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "segment-display.cpp"; sourceTree = "<group>"; };
+		F6D1F0AA2F3D0001000A0AA1 /* display-frame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "display-frame.h"; sourceTree = "<group>"; };
 		F6AAEE1E2F261A790020CF32 /* ff777-ursa-minor-throttle-profile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ff777-ursa-minor-throttle-profile.h"; sourceTree = "<group>"; };
 		F6AAEE1F2F261A790020CF32 /* ff777-ursa-minor-throttle-profile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "ff777-ursa-minor-throttle-profile.cpp"; sourceTree = "<group>"; };
 		F6AAEE202F261A790020CF32 /* zibo-ursa-minor-throttle-profile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "zibo-ursa-minor-throttle-profile.h"; sourceTree = "<group>"; };
@@ -861,6 +862,7 @@
 				F6C248452EBE498500617E89 /* plugins-menu.cpp */,
 				F6A77E772ED3620600061D03 /* segment-display.h */,
 				F6A77E782ED3620600061D03 /* segment-display.cpp */,
+				F6D1F0AA2F3D0001000A0AA1 /* display-frame.h */,
 				F65361742FA244A90039C2C9 /* power-scheme.h */,
 				F65361752FA244A90039C2C9 /* power-scheme.cpp */,
 				F6B79CFC2F4A5BFD00517E6A /* logger.hpp */,

--- a/src/include/products/agp/product-agp.cpp
+++ b/src/include/products/agp/product-agp.cpp
@@ -171,57 +171,6 @@ void ProductAGP::setLedBrightness(AGPLed led, uint8_t brightness) {
     writeData({0x02, ProductAGP::IdentifierByte, 0xBB, 0x00, 0x00, 0x03, 0x49, static_cast<uint8_t>(led), brightness, 0x00, 0x00, 0x00, 0x00, 0x00});
 }
 
-void ProductAGP::parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset) {
-    std::string digits;
-    uint16_t localColonMask = 0;
-
-    for (size_t i = 0; i < text.length(); ++i) {
-        char c = text[i];
-        if (c == ':' || c == '.') {
-            if (!digits.empty()) {
-                if (expectedLength >= 6) {
-                    // Standard: Enable bit for digit before (Left) and digit after (Right)
-
-                    if (c == ':') {
-                        localColonMask |= (1 << (digits.length() - 1)); // Upper Dot
-                    }
-
-                    localColonMask |= (1 << digits.length()); // Lower Dot
-                } else {
-                    // 4-Digit Displays: Enable bit for digit after (Right) and next digit (Right + 1)
-                    // The digit 'digits.length()' is the one we are about to add next.
-
-                    if (c == ':') {
-                        localColonMask |= (1 << digits.length()); // Upper Dot
-                    }
-
-                    localColonMask |= (1 << (digits.length() + 1)); // Lower Dot
-                }
-            }
-        } else {
-            digits += c;
-        }
-    }
-
-    // Calculate padding amount before modifying digits
-    int paddingAmount = 0;
-    if (digits.length() < static_cast<size_t>(expectedLength)) {
-        paddingAmount = expectedLength - static_cast<int>(digits.length());
-    }
-
-    // Shift colon positions by padding amount and add to global mask with offset
-    colonMask |= (localColonMask << paddingAmount) << digitOffset;
-
-    // Pad or truncate to expected length
-    while (digits.length() < static_cast<size_t>(expectedLength)) {
-        digits = ' ' + digits; // Left-pad with spaces
-    }
-    if (digits.length() > static_cast<size_t>(expectedLength)) {
-        digits = digits.substr(digits.length() - expectedLength);
-    }
-    outDigits += digits;
-}
-
 void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTime, const std::string &elapsedTime) {
     std::vector<uint8_t> packet = {
         0xF0, 0x00, packetNumber, 0x35, ProductAGP::IdentifierByte,
@@ -229,35 +178,17 @@ void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTim
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[8] = {25, 29, 33, 37, 41, 45, 49, 53};
+    const int segmentRowOffsets[7] = {25, 29, 33, 37, 41, 45, 49};
+    const int colonRowOffset = 53;
 
     std::string allDigits;
     uint16_t colonMask = 0;
 
-    parseSegment(chrono, 4, allDigits, colonMask, 0);
-    parseSegment(utcTime, 6, allDigits, colonMask, 4);
-    parseSegment(elapsedTime, 4, allDigits, colonMask, 10);
+    SegmentDisplay::parseSegmentText(chrono, 4, allDigits, colonMask, 0, SegmentDisplay::DotPlacement::DualDot);
+    SegmentDisplay::parseSegmentText(utcTime, 6, allDigits, colonMask, 4, SegmentDisplay::DotPlacement::DualDot);
+    SegmentDisplay::parseSegmentText(elapsedTime, 4, allDigits, colonMask, 10, SegmentDisplay::DotPlacement::DualDot);
 
-    for (int digitIndex = 0; digitIndex < 14; ++digitIndex) {
-        char c = allDigits[digitIndex];
-        uint8_t charMask = SegmentDisplay::getSegmentMask(c);
-
-        for (int segIndex = 0; segIndex < 7; ++segIndex) {
-            if (charMask & (1 << segIndex)) {
-                int byteOffset = rowOffsets[segIndex] + (digitIndex / 8);
-
-                int bitPos = digitIndex % 8;
-
-                packet[byteOffset] |= (1 << bitPos);
-            }
-        }
-
-        if (colonMask & (1 << digitIndex)) {
-            int byteOffset = rowOffsets[7] + (digitIndex / 8);
-            int bitPos = digitIndex % 8;
-            packet[byteOffset] |= (1 << bitPos);
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, allDigits, colonMask, segmentRowOffsets, 7, colonRowOffset);
 
     writeData(packet);
 

--- a/src/include/products/agp/product-agp.cpp
+++ b/src/include/products/agp/product-agp.cpp
@@ -3,6 +3,7 @@
 #include "appstate.h"
 #include "config.h"
 #include "dataref.h"
+#include "display-frame.h"
 #include "plugins-menu.h"
 #include "profiles/pa28-agp-profile.h"
 #include "profiles/rotatemd11-agp-profile.h"
@@ -172,11 +173,7 @@ void ProductAGP::setLedBrightness(AGPLed led, uint8_t brightness) {
 }
 
 void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTime, const std::string &elapsedTime) {
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x35, ProductAGP::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-        0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    packet.resize(64, 0x00);
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x35, ProductAGP::IdentifierByte, 0xBB);
 
     const int segmentRowOffsets[7] = {25, 29, 33, 37, 41, 45, 49};
     const int colonRowOffset = 53;
@@ -192,14 +189,8 @@ void ProductAGP::setLCDText(const std::string &chrono, const std::string &utcTim
 
     writeData(packet);
 
-    std::vector<uint8_t> commitPacket = {
-        0xF0, 0x00, packetNumber, 0x11, ProductAGP::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00};
-    commitPacket.resize(64, 0x00);
-    writeData(commitPacket);
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    writeData(DisplayFrame::buildCommitFrame(packetNumber, ProductAGP::IdentifierByte, 0xBB));
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductAGP::didReceiveData(int reportId, uint8_t *report, int reportLength) {

--- a/src/include/products/agp/product-agp.h
+++ b/src/include/products/agp/product-agp.h
@@ -48,7 +48,6 @@ class ProductAGP : public USBDevice {
         uint8_t packetNumber = 1;
 
         void setProfileForCurrentAircraft();
-        void parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset);
 
     public:
         ProductAGP(HIDDeviceHandle hidDevice, uint16_t vendorId, uint16_t productId, std::string vendorName, std::string productName);

--- a/src/include/products/fcu-efis/product-fcu-efis.cpp
+++ b/src/include/products/fcu-efis/product-fcu-efis.cpp
@@ -3,6 +3,7 @@
 #include "appstate.h"
 #include "config.h"
 #include "dataref.h"
+#include "display-frame.h"
 #include "plugins-menu.h"
 #include "profiles/a220-fcu-efis-profile.h"
 #include "profiles/b58-fcu-efis-profile.h"
@@ -429,8 +430,7 @@ void ProductFCUEfis::sendFCUDisplay(const std::string &speed, const std::string 
     }
 
     // First request - send display data
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x31, ProductFCUEfis::FCUIdentifierByte, 0xBB, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x02, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x31, ProductFCUEfis::FCUIdentifierByte, 0xBB, 0x02, 0x20);
 
     // Add speed data (3 bytes)
     packet.push_back(speedData[2]);
@@ -465,18 +465,8 @@ void ProductFCUEfis::sendFCUDisplay(const std::string &speed, const std::string 
     writeData(packet);
 
     // Second request - commit display data
-    std::vector<uint8_t> commitPacket = {
-        0xF0, 0x00, packetNumber, 0x11, ProductFCUEfis::FCUIdentifierByte, 0xBB, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x02, 0x00};
-
-    // Pad to 64 bytes
-    while (commitPacket.size() < 64) {
-        commitPacket.push_back(0x00);
-    }
-
-    writeData(commitPacket);
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    writeData(DisplayFrame::buildCommitFrame(packetNumber, ProductFCUEfis::FCUIdentifierByte, 0xBB, 0x02));
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductFCUEfis::sendEfisDisplayWithFlags(EfisDisplayValue *data, bool isRightSide) {
@@ -487,8 +477,7 @@ void ProductFCUEfis::sendEfisDisplayWithFlags(EfisDisplayValue *data, bool isRig
     }
 
     // EFIS display protocol
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x1A, static_cast<uint8_t>(isRightSide ? ProductFCUEfis::EfisRightIdentifierByte : ProductFCUEfis::EfisLeftIdentifierByte), 0xBF, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x1D, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x1A, static_cast<uint8_t>(isRightSide ? ProductFCUEfis::EfisRightIdentifierByte : ProductFCUEfis::EfisLeftIdentifierByte), 0xBF, 0x1D, 0x09);
 
     // Add barometric data
     auto baroData = SegmentDisplay::encodeStringEfis(4, SegmentDisplay::fixStringLength(data->isStd ? "STD " : data->baro, 4));
@@ -520,14 +509,13 @@ void ProductFCUEfis::sendEfisDisplayWithFlags(EfisDisplayValue *data, bool isRig
 
     writeData(packet);
 
+    // EFIS commit frame deviates from the standard template at bytes 12..15
     std::vector<uint8_t> commitPacket = {
         0xF0, 0x00, packetNumber, 0x11, static_cast<uint8_t>(isRightSide ? ProductFCUEfis::EfisRightIdentifierByte : ProductFCUEfis::EfisLeftIdentifierByte),
         0xBF, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0x4C, 0x0C, 0x1D, 0x00};
     commitPacket.resize(64, 0x00);
     writeData(commitPacket);
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductFCUEfis::setAllLedsEnabled(bool enable) {

--- a/src/include/products/rmp/product-rmp.cpp
+++ b/src/include/products/rmp/product-rmp.cpp
@@ -255,41 +255,6 @@ void ProductRMP::setLedBrightness(RMPLed led, uint8_t brightness) {
     writeData({0x02, ProductRMP::IdentifierByte, 0xBB, 0x00, 0x00, 0x03, 0x49, static_cast<uint8_t>(led), brightness, 0x00, 0x00, 0x00, 0x00, 0x00});
 }
 
-void ProductRMP::parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset) {
-    std::string digits;
-    uint16_t localColonMask = 0;
-
-    for (size_t i = 0; i < text.length(); ++i) {
-        char c = text[i];
-        if (c == '.' && !digits.empty()) {
-            localColonMask |= (1 << (digits.length() - 1));
-        } else if (c == '/') {
-            /* ToLiss datarefs use a C/course format for backup nav */
-            digits += '-';
-        } else {
-            digits += c;
-        }
-    }
-
-    // Calculate padding amount before modifying digits
-    int paddingAmount = 0;
-    if (digits.length() < static_cast<size_t>(expectedLength)) {
-        paddingAmount = expectedLength - static_cast<int>(digits.length());
-    }
-
-    // Shift colon positions by padding amount and add to global mask with offset
-    colonMask |= (localColonMask << paddingAmount) << digitOffset;
-
-    // Pad or truncate to expected length
-    while (digits.length() < static_cast<size_t>(expectedLength)) {
-        digits = ' ' + digits; // Left-pad with spaces
-    }
-    if (digits.length() > static_cast<size_t>(expectedLength)) {
-        digits = digits.substr(digits.length() - expectedLength);
-    }
-    outDigits += digits;
-}
-
 void ProductRMP::setDisplayText(const std::string &active, const std::string &stby) {
     if (active == cachedActiveDisplay && stby == cachedStbyDisplay) {
         return;
@@ -309,8 +274,9 @@ void ProductRMP::setDisplayText(const std::string &active, const std::string &st
     uint16_t colonMask = 0;
 
     /* Standby is first, Active is second */
-    parseSegment(stby, 6, allDigits, colonMask, 0);
-    parseSegment(active, 6, allDigits, colonMask, 6);
+    /* ToLiss datarefs use a C/course format for backup nav, hence the '/' -> '-' replacement */
+    SegmentDisplay::parseSegmentText(stby, 6, allDigits, colonMask, 0, SegmentDisplay::DotPlacement::PrecedingDigit, '-');
+    SegmentDisplay::parseSegmentText(active, 6, allDigits, colonMask, 6, SegmentDisplay::DotPlacement::PrecedingDigit, '-');
 
     for (int digitIndex = 0; digitIndex < 12; ++digitIndex) {
         char c = allDigits[digitIndex];

--- a/src/include/products/rmp/product-rmp.cpp
+++ b/src/include/products/rmp/product-rmp.cpp
@@ -2,6 +2,7 @@
 
 #include "appstate.h"
 #include "dataref.h"
+#include "display-frame.h"
 #include "plugins-menu.h"
 #include "profiles/ff777-rmp-profile.h"
 #include "profiles/toliss-rmp-profile.h"
@@ -262,11 +263,7 @@ void ProductRMP::setDisplayText(const std::string &active, const std::string &st
     cachedActiveDisplay = active;
     cachedStbyDisplay = stby;
 
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x35, ProductRMP::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-        0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    packet.resize(64, 0x00);
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x35, ProductRMP::IdentifierByte, 0xBB);
 
     const int byteOffset = 25;
 
@@ -291,14 +288,8 @@ void ProductRMP::setDisplayText(const std::string &active, const std::string &st
 
     writeData(packet);
 
-    std::vector<uint8_t> commitPacket = {
-        0xF0, 0x00, packetNumber, 0x11, ProductRMP::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00};
-    commitPacket.resize(64, 0x00);
-    writeData(commitPacket);
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    writeData(DisplayFrame::buildCommitFrame(packetNumber, ProductRMP::IdentifierByte, 0xBB));
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductRMP::forceStateSync() {

--- a/src/include/products/rmp/product-rmp.h
+++ b/src/include/products/rmp/product-rmp.h
@@ -53,7 +53,6 @@ class ProductRMP : public USBDevice {
         std::string cachedStbyDisplay;
 
         void setProfileForCurrentAircraft();
-        void parseSegment(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &colonMask, int digitOffset);
         const char *positionName() const;
         std::string variantPreferenceKey() const;
 

--- a/src/include/products/tcas/product-tcas.cpp
+++ b/src/include/products/tcas/product-tcas.cpp
@@ -175,24 +175,9 @@ void ProductTCAS::setLCDText(const std::string &squawkCode) {
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[7] = {37, 33, 29, 25, 49, 45, 41};
+    const int segmentRowOffsets[7] = {37, 33, 29, 25, 49, 45, 41};
 
-    std::string allDigits = squawkCode;
-
-    for (int digitIndex = 0; digitIndex < 4; ++digitIndex) {
-        if (digitIndex < static_cast<int>(allDigits.length())) {
-            char c = allDigits[digitIndex];
-            uint8_t charMask = SegmentDisplay::getSegmentMask(c);
-
-            for (int segIndex = 0; segIndex < 7; ++segIndex) {
-                if (charMask & (1 << segIndex)) {
-                    int byteOffset = rowOffsets[segIndex] + (digitIndex / 8);
-                    int bitPos = digitIndex % 8;
-                    packet[byteOffset] |= (1 << bitPos);
-                }
-            }
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, squawkCode, 0, segmentRowOffsets, 7, -1);
 
     writeData(packet);
 

--- a/src/include/products/tcas/product-tcas.cpp
+++ b/src/include/products/tcas/product-tcas.cpp
@@ -3,6 +3,7 @@
 #include "appstate.h"
 #include "config.h"
 #include "dataref.h"
+#include "display-frame.h"
 #include "plugins-menu.h"
 #include "profiles/fps748-tcas-profile.h"
 #include "profiles/pa28-tcas-profile.h"
@@ -169,11 +170,7 @@ void ProductTCAS::setLedBrightness(TCASLed led, uint8_t brightness) {
 }
 
 void ProductTCAS::setLCDText(const std::string &squawkCode) {
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x35, ProductTCAS::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-        0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    packet.resize(64, 0x00);
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x35, ProductTCAS::IdentifierByte, 0xBB);
 
     const int segmentRowOffsets[7] = {37, 33, 29, 25, 49, 45, 41};
 
@@ -181,14 +178,8 @@ void ProductTCAS::setLCDText(const std::string &squawkCode) {
 
     writeData(packet);
 
-    std::vector<uint8_t> commitPacket = {
-        0xF0, 0x00, packetNumber, 0x11, ProductTCAS::IdentifierByte,
-        0xBB, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00};
-    commitPacket.resize(64, 0x00);
-    writeData(commitPacket);
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    writeData(DisplayFrame::buildCommitFrame(packetNumber, ProductTCAS::IdentifierByte, 0xBB));
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductTCAS::didReceiveData(int reportId, uint8_t *report, int reportLength) {

--- a/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
+++ b/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
@@ -201,15 +201,14 @@ void ProductUrsaMinorThrottle::setVibration(uint8_t vibration, bool leftSide, bo
 }
 
 void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
-    bool unknownFlag = false;
     std::vector<uint8_t> packet = {
         0xF0, 0x00, packetNumber, 0x35, ProductUrsaMinorThrottle::PACIdentifierByte, 0xB9,
         0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
         0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     packet.resize(64, 0x00);
 
-    const int rowOffsets[9] = {53, 49, 45, 41, 37, 33, 29, 25, 57};
-    const int digitBits[4] = {0, 1, 2, 3};
+    const int segmentRowOffsets[7] = {53, 49, 45, 41, 37, 33, 29};
+    const int dotRowOffset = 25;
 
     std::string charsOnly = "";
     uint8_t dotsMask = 0;
@@ -247,36 +246,7 @@ void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
         charsOnly += " ";
     }
 
-    for (int i = 0; i < 4; ++i) {
-        char c = charsOnly[i];
-        int targetBit = digitBits[i];
-
-        uint16_t mask = SegmentDisplay::getSegmentMask(c);
-
-        // Apply the unknown flag ONLY to the first character (L or R)
-        if (i == 0 && unknownFlag) {
-            mask |= 0x100; // Set Bit 8
-        }
-
-        for (int segIndex = 0; segIndex < 9; ++segIndex) {
-            bool turnOn = false;
-
-            if (segIndex == 7) {
-                if ((dotsMask >> i) & 1) {
-                    turnOn = true;
-                }
-            } else {
-                if ((mask >> segIndex) & 1) {
-                    turnOn = true;
-                }
-            }
-
-            if (turnOn) {
-                int byteOffset = rowOffsets[segIndex];
-                packet[byteOffset] |= (1 << targetBit);
-            }
-        }
-    }
+    SegmentDisplay::encodeBitplane(packet, charsOnly, dotsMask, segmentRowOffsets, 7, dotRowOffset);
 
     writeData(packet);
 

--- a/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
+++ b/src/include/products/ursa-minor-throttle/product-ursa-minor-throttle.cpp
@@ -2,6 +2,7 @@
 
 #include "appstate.h"
 #include "dataref.h"
+#include "display-frame.h"
 #include "plugins-menu.h"
 #include "profiles/ff777-ursa-minor-throttle-profile.h"
 #include "profiles/pa28-ursa-minor-throttle-profile.h"
@@ -201,11 +202,7 @@ void ProductUrsaMinorThrottle::setVibration(uint8_t vibration, bool leftSide, bo
 }
 
 void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
-    std::vector<uint8_t> packet = {
-        0xF0, 0x00, packetNumber, 0x35, ProductUrsaMinorThrottle::PACIdentifierByte, 0xB9,
-        0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
-        0x00, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    packet.resize(64, 0x00);
+    std::vector<uint8_t> packet = DisplayFrame::buildDataFrame(packetNumber, 0x35, ProductUrsaMinorThrottle::PACIdentifierByte, 0xB9);
 
     const int segmentRowOffsets[7] = {53, 49, 45, 41, 37, 33, 29};
     const int dotRowOffset = 25;
@@ -250,15 +247,8 @@ void ProductUrsaMinorThrottle::setLCDText(const std::string &text) {
 
     writeData(packet);
 
-    std::vector<uint8_t> commitPacket = {
-        0xF0, 0x00, packetNumber, 0x11, 0x01, 0xB9,
-        0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00};
-    commitPacket.resize(64, 0x00);
-    writeData(commitPacket);
-
-    if (++packetNumber == 0) {
-        packetNumber = 1;
-    }
+    writeData(DisplayFrame::buildCommitFrame(packetNumber, 0x01, 0xB9));
+    DisplayFrame::advancePacketNumber(packetNumber);
 }
 
 void ProductUrsaMinorThrottle::forceStateSync() {

--- a/src/include/utils/display-frame.h
+++ b/src/include/utils/display-frame.h
@@ -1,0 +1,70 @@
+#ifndef DISPLAY_FRAME_H
+#define DISPLAY_FRAME_H
+
+#include <cstdint>
+#include <vector>
+
+// ===================================================================
+// DISPLAY FRAME PROTOCOL (0xF0 frame family)
+// ===================================================================
+// Shared by AGP, TCAS, RMP, FCU/EFIS and URSA Minor Throttle displays.
+// Every LCD update is a two-step transaction: a data frame followed by a
+// commit frame, both 64-byte HID output reports sharing one template:
+//
+//   [0..1]  0xF0 0x00              frame magic
+//   [2]     packetNumber           rolling counter, 1..255
+//   [3]     opcode                 data opcode (device specific) or 0x11 commit
+//   [4]     identifierByte         device/board identifier
+//   [5]     familyMarker           protocol family (0xBB / 0xB9 / 0xBF)
+//   [8]     0x02 data / 0x03 commit
+//   [9]     0x01
+//   [12..13] 0xFF 0xFF
+//   [14]    extendedId             device specific (data frames only)
+//   [17]    payloadTag             device specific (data frames only)
+namespace DisplayFrame {
+
+    // Build a 64-byte zeroed data frame with the header filled in.
+    // Display payload bytes are appended starting at index 25 by the caller.
+    inline std::vector<uint8_t> buildDataFrame(uint8_t packetNumber, uint8_t opcode, uint8_t identifierByte, uint8_t familyMarker, uint8_t extendedId = 0x00, uint8_t payloadTag = 0x24) {
+        std::vector<uint8_t> packet(64, 0x00);
+        packet[0] = 0xF0;
+        packet[2] = packetNumber;
+        packet[3] = opcode;
+        packet[4] = identifierByte;
+        packet[5] = familyMarker;
+        packet[8] = 0x02;
+        packet[9] = 0x01;
+        packet[12] = 0xFF;
+        packet[13] = 0xFF;
+        packet[14] = extendedId;
+        packet[17] = payloadTag;
+        return packet;
+    }
+
+    // Build a 64-byte zeroed commit frame (opcode 0x11) that flushes the
+    // previously sent data frame to the display.
+    inline std::vector<uint8_t> buildCommitFrame(uint8_t packetNumber, uint8_t identifierByte, uint8_t familyMarker, uint8_t extendedId = 0x00) {
+        std::vector<uint8_t> packet(64, 0x00);
+        packet[0] = 0xF0;
+        packet[2] = packetNumber;
+        packet[3] = 0x11;
+        packet[4] = identifierByte;
+        packet[5] = familyMarker;
+        packet[8] = 0x03;
+        packet[9] = 0x01;
+        packet[12] = 0xFF;
+        packet[13] = 0xFF;
+        packet[14] = extendedId;
+        return packet;
+    }
+
+    // Advance the rolling frame counter, skipping zero.
+    inline void advancePacketNumber(uint8_t &packetNumber) {
+        if (++packetNumber == 0) {
+            packetNumber = 1;
+        }
+    }
+
+}
+
+#endif

--- a/src/include/utils/segment-display.cpp
+++ b/src/include/utils/segment-display.cpp
@@ -401,4 +401,88 @@ namespace SegmentDisplay {
 
         return result;
     }
+
+    void parseSegmentText(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &dotMask, int digitOffset, DotPlacement dotPlacement, char slashReplacement) {
+        std::string digits;
+        uint16_t localDotMask = 0;
+
+        for (char c : text) {
+            const bool isSeparator = (c == '.') || (c == ':' && dotPlacement == DotPlacement::DualDot);
+
+            if (isSeparator && digits.empty() && dotPlacement == DotPlacement::PrecedingDigit) {
+                // No preceding digit to attach the dot to; keep the character as-is
+                digits += c;
+                continue;
+            }
+
+            if (isSeparator) {
+                if (digits.empty()) {
+                    continue;
+                }
+
+                switch (dotPlacement) {
+                    case DotPlacement::PrecedingDigit:
+                        localDotMask |= (1 << (digits.length() - 1));
+                        break;
+                    case DotPlacement::DualDot:
+                        if (expectedLength >= 6) {
+                            // Standard: dot bits for digit before (Left) and digit after (Right)
+                            if (c == ':') {
+                                localDotMask |= (1 << (digits.length() - 1)); // Upper Dot
+                            }
+                            localDotMask |= (1 << digits.length()); // Lower Dot
+                        } else {
+                            // 4-Digit Displays: dot bits for digit after (Right) and next digit (Right + 1)
+                            if (c == ':') {
+                                localDotMask |= (1 << digits.length()); // Upper Dot
+                            }
+                            localDotMask |= (1 << (digits.length() + 1)); // Lower Dot
+                        }
+                        break;
+                }
+            } else if (slashReplacement != '\0' && c == '/') {
+                digits += slashReplacement;
+            } else {
+                digits += c;
+            }
+        }
+
+        // Calculate padding amount before modifying digits
+        int paddingAmount = 0;
+        if (digits.length() < static_cast<size_t>(expectedLength)) {
+            paddingAmount = expectedLength - static_cast<int>(digits.length());
+        }
+
+        // Shift dot positions by padding amount and add to global mask with offset
+        dotMask |= (localDotMask << paddingAmount) << digitOffset;
+
+        // Pad or truncate to expected length
+        while (digits.length() < static_cast<size_t>(expectedLength)) {
+            digits = ' ' + digits; // Left-pad with spaces
+        }
+        if (digits.length() > static_cast<size_t>(expectedLength)) {
+            digits = digits.substr(digits.length() - expectedLength);
+        }
+        outDigits += digits;
+    }
+
+    void encodeBitplane(std::vector<uint8_t> &packet, const std::string &digits, uint16_t dotMask, const int *segmentRowOffsets, int numSegmentRows, int dotRowOffset) {
+        for (int digitIndex = 0; digitIndex < static_cast<int>(digits.length()); ++digitIndex) {
+            uint8_t charMask = getSegmentMask(digits[digitIndex]);
+
+            for (int segIndex = 0; segIndex < numSegmentRows; ++segIndex) {
+                if (charMask & (1 << segIndex)) {
+                    int byteOffset = segmentRowOffsets[segIndex] + (digitIndex / 8);
+                    int bitPos = digitIndex % 8;
+                    packet[byteOffset] |= (1 << bitPos);
+                }
+            }
+
+            if (dotRowOffset >= 0 && (dotMask & (1 << digitIndex))) {
+                int byteOffset = dotRowOffset + (digitIndex / 8);
+                int bitPos = digitIndex % 8;
+                packet[byteOffset] |= (1 << bitPos);
+            }
+        }
+    }
 }

--- a/src/include/utils/segment-display.h
+++ b/src/include/utils/segment-display.h
@@ -30,6 +30,27 @@ namespace SegmentDisplay {
     // AGP 2-byte per digit encoding (little-endian format)
     std::vector<uint8_t> encodeStringAGP(int numSegments, const std::string &str);
 
+    // Dot/colon placement scheme used when parsing display text
+    enum class DotPlacement {
+        // Dot attaches to the digit right before the separator (e.g. RMP frequency decimal point)
+        PrecedingDigit,
+        // Colon renders as two dots around the separator position (AGP clock displays)
+        DualDot,
+    };
+
+    // Parse display text into fixed-width digits plus a dot-position bitmask.
+    // Separators ('.' and ':') are removed from the digit stream and recorded as dot bits.
+    // Digits are right-aligned (left-padded with spaces) to expectedLength and appended to outDigits.
+    // The local dot bits are shifted by the padding amount and digitOffset before being OR-ed into dotMask.
+    // slashReplacement, when not '\0', substitutes '/' characters in the digit stream.
+    void parseSegmentText(const std::string &text, int expectedLength, std::string &outDigits, uint16_t &dotMask, int digitOffset, DotPlacement dotPlacement, char slashReplacement = '\0');
+
+    // Encode digits (and optional dots) into a packet using bitplane row offsets.
+    // segmentRowOffsets[seg] gives the packet byte offset holding segment bit 'seg' for digit 0;
+    // digits beyond the first 8 continue into subsequent bytes (offset + digit / 8, bit digit % 8).
+    // dotRowOffset is the base packet byte offset for dot/colon bits; pass -1 to disable dots.
+    void encodeBitplane(std::vector<uint8_t> &packet, const std::string &digits, uint16_t dotMask, const int *segmentRowOffsets, int numSegmentRows, int dotRowOffset);
+
 }
 
 #endif


### PR DESCRIPTION
Extract the duplicated 64-byte 0xF0 LCD frame template (data frame + commit frame + packet counter) shared by AGP, RMP, TCAS, FCU-EFIS and URSA throttle into common DisplayFrame helpers, removing about 100 lines of copy-pasted protocol boilerplate