### PR TITLE
Fix: Refresh the correct dataref on FF777 throttle power change.

### DIFF
--- a/src/include/products/ursa-minor-throttle/profiles/ff777-ursa-minor-throttle-profile.cpp
+++ b/src/include/products/ursa-minor-throttle/profiles/ff777-ursa-minor-throttle-profile.cpp
@@ -27,7 +27,7 @@ FF777UrsaMinorThrottleProfile::FF777UrsaMinorThrottleProfile(ProductUrsaMinorThr
         this);
 
     Dataref::getInstance()->monitorExistingDataref<bool>("1-sim/output/mcp/ok", [product](bool hasPower) {
-        Dataref::getInstance()->executeChangedCallbacksForDataref("1-sim/ckpt/lights/glareshield");
+        Dataref::getInstance()->executeChangedCallbacksForDataref("1-sim/ckpt/lights/aisle");
     },
         this);
 


### PR DESCRIPTION
Was refreshing glareshield (copy-paste from PDC). Should be aisle, which this profile actually monitors for backlight.