### PR TITLE
Cleanup: Dedup AGP date/time formatting into SegmentDisplay helpers.

### DIFF
--- a/src/include/products/agp/profiles/pa28-agp-profile.cpp
+++ b/src/include/products/agp/profiles/pa28-agp-profile.cpp
@@ -7,9 +7,6 @@
 #include "logger.hpp"
 
 #include <algorithm>
-#include <chrono>
-#include <cmath>
-#include <ctime>
 
 PA28AGPProfile::PA28AGPProfile(ProductAGP *product) : AGPAircraftProfile(product) {
     // Same lighting approach as the PA28 FCU profile: LCD and LEDs on with battery power,
@@ -116,52 +113,16 @@ void PA28AGPProfile::updateDisplays() {
     float chronoSeconds = datarefManager->get<float>("sim/time/timer_elapsed_time_sec");
     bool chronoRunning = datarefManager->get<bool>("sim/time/timer_is_running_sec");
     if (chronoRunning || chronoSeconds > std::numeric_limits<float>::epsilon()) {
-        int totalSeconds = static_cast<int>(std::floor(chronoSeconds));
-        int mins = totalSeconds / 60;
-        int secs = totalSeconds % 60;
-        chrono = SegmentDisplay::fixStringLength(std::to_string(mins), 2) + ":" +
-                 SegmentDisplay::fixStringLength(std::to_string(secs), 2);
+        chrono = SegmentDisplay::formatSecondsAsMinSec(chronoSeconds);
     }
 
     std::string utc = "";
     if (showDate) {
         int dayOfYear = datarefManager->get<int>("sim/time/local_date_days") + 1;
-
-        auto now = std::chrono::system_clock::now();
-        std::time_t time = std::chrono::system_clock::to_time_t(now);
-        struct tm *timeinfo = std::localtime(&time);
-        int year = timeinfo->tm_year + 1900;
-
-        // Calculate month and day from day of year
-        int month = 1;
-        int day = dayOfYear;
-        int daysInMonth[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-
-        if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)) {
-            daysInMonth[1] = 29;
-        }
-
-        for (int i = 0; i < 12; i++) {
-            if (day <= daysInMonth[i]) {
-                month = i + 1;
-                break;
-            }
-            day -= daysInMonth[i];
-        }
-
-        utc = (month < 10 ? "0" : "") + std::to_string(month) + ":" +
-              (day < 10 ? "0" : "") + std::to_string(day) + ":" +
-              std::to_string(year % 100);
+        utc = SegmentDisplay::formatDateFromDayOfYear(dayOfYear);
     } else {
         double zuluTime = datarefManager->get<double>("sim/time/zulu_time_sec");
-
-        int hours = static_cast<int>(zuluTime / 3600) % 24;
-        int minutes = static_cast<int>(zuluTime / 60) % 60;
-        int seconds = static_cast<int>(zuluTime) % 60;
-
-        utc = SegmentDisplay::fixStringLength(std::to_string(hours), 2) + ":" +
-              SegmentDisplay::fixStringLength(std::to_string(minutes), 2) + ":" +
-              SegmentDisplay::fixStringLength(std::to_string(seconds), 2);
+        utc = SegmentDisplay::formatTimeFromSecondsOfDay(zuluTime);
     }
 
     std::string elapsedTime = "";

--- a/src/include/products/agp/profiles/rotatemd11-agp-profile.cpp
+++ b/src/include/products/agp/profiles/rotatemd11-agp-profile.cpp
@@ -129,13 +129,7 @@ void RotateMD11AGPProfile::updateDisplays() {
     }
 
     double zuluTime = Dataref::getInstance()->get<double>("sim/time/zulu_time_sec");
-    int hours = static_cast<int>(zuluTime / 3600) % 24;
-    int minutes = static_cast<int>(zuluTime / 60) % 60;
-    int seconds = static_cast<int>(zuluTime) % 60;
-
-    std::string utc = SegmentDisplay::fixStringLength(std::to_string(hours), 2) + ":" +
-                      SegmentDisplay::fixStringLength(std::to_string(minutes), 2) + ":" +
-                      SegmentDisplay::fixStringLength(std::to_string(seconds), 2);
+    std::string utc = SegmentDisplay::formatTimeFromSecondsOfDay(zuluTime);
 
     product->setLCDText("", utc, "");
 }

--- a/src/include/products/agp/profiles/toliss-agp-profile.cpp
+++ b/src/include/products/agp/profiles/toliss-agp-profile.cpp
@@ -7,7 +7,6 @@
 #include "xplane-version.hpp"
 
 #include <algorithm>
-#include <cmath>
 
 TolissAGPProfile::TolissAGPProfile(ProductAGP *product) : AGPAircraftProfile(product) {
     Dataref::getInstance()->monitorExistingDataref<float>("AirbusFBW/PanelBrightnessLevel", [product](float brightness) {
@@ -178,11 +177,7 @@ void TolissAGPProfile::updateDisplays() {
     std::string chrono = "";
     float chronoSeconds = datarefManager->get<float>("AirbusFBW/ClockChronoValue");
     if (chronoSeconds > std::numeric_limits<float>::epsilon()) {
-        int totalSeconds = static_cast<int>(std::floor(chronoSeconds));
-        int mins = totalSeconds / 60;
-        int secs = totalSeconds % 60;
-        chrono = SegmentDisplay::fixStringLength(std::to_string(mins), 2) + ":" +
-                 SegmentDisplay::fixStringLength(std::to_string(secs), 2);
+        chrono = SegmentDisplay::formatSecondsAsMinSec(chronoSeconds);
     }
 
     std::string utc = "";
@@ -190,44 +185,10 @@ void TolissAGPProfile::updateDisplays() {
     bool dateButtonPressed = buttonAnimations.size() > 2 && buttonAnimations[2] > std::numeric_limits<float>::epsilon();
     if (dateButtonPressed) {
         int dayOfYear = datarefManager->get<int>("sim/time/local_date_days") + 1;
-
-        auto now = std::chrono::system_clock::now();
-        std::time_t time = std::chrono::system_clock::to_time_t(now);
-        struct tm *timeinfo = std::localtime(&time);
-        int year = timeinfo->tm_year + 1900;
-
-        // Calculate month and day from day of year
-        int month = 1;
-        int day = dayOfYear;
-        int daysInMonth[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-
-        if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)) {
-            daysInMonth[1] = 29;
-        }
-
-        for (int i = 0; i < 12; i++) {
-            if (day <= daysInMonth[i]) {
-                month = i + 1;
-                break;
-            }
-            day -= daysInMonth[i];
-        }
-
-        // Format the date as MMDDYY
-        utc = (month < 10 ? "0" : "") + std::to_string(month) + ":" +
-              (day < 10 ? "0" : "") + std::to_string(day) + ":" +
-              std::to_string(year % 100);
+        utc = SegmentDisplay::formatDateFromDayOfYear(dayOfYear);
     } else {
         double zuluTime = datarefManager->get<double>("sim/time/zulu_time_sec");
-
-        // Convert zulu time in seconds to HH:MM:SS
-        int hours = static_cast<int>(zuluTime / 3600) % 24;
-        int minutes = static_cast<int>(zuluTime / 60) % 60;
-        int seconds = static_cast<int>(zuluTime) % 60;
-
-        utc = SegmentDisplay::fixStringLength(std::to_string(hours), 2) + ":" +
-              SegmentDisplay::fixStringLength(std::to_string(minutes), 2) + ":" +
-              SegmentDisplay::fixStringLength(std::to_string(seconds), 2);
+        utc = SegmentDisplay::formatTimeFromSecondsOfDay(zuluTime);
     }
 
     std::string elapsedTime = "";

--- a/src/include/utils/segment-display.cpp
+++ b/src/include/utils/segment-display.cpp
@@ -1,6 +1,9 @@
 #include "segment-display.h"
 
 #include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <ctime>
 #include <map>
 
 namespace SegmentDisplay {
@@ -201,6 +204,52 @@ namespace SegmentDisplay {
             result = fillChar + result;
         }
         return result;
+    }
+
+    std::string formatDateFromDayOfYear(int dayOfYear) {
+        auto now = std::chrono::system_clock::now();
+        std::time_t time = std::chrono::system_clock::to_time_t(now);
+        struct tm *timeinfo = std::localtime(&time);
+        int year = timeinfo->tm_year + 1900;
+
+        int month = 1;
+        int day = dayOfYear;
+        int daysInMonth[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+        if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)) {
+            daysInMonth[1] = 29;
+        }
+
+        for (int i = 0; i < 12; i++) {
+            if (day <= daysInMonth[i]) {
+                month = i + 1;
+                break;
+            }
+            day -= daysInMonth[i];
+        }
+
+        return (month < 10 ? "0" : "") + std::to_string(month) + ":" +
+               (day < 10 ? "0" : "") + std::to_string(day) + ":" +
+               std::to_string(year % 100);
+    }
+
+    std::string formatTimeFromSecondsOfDay(double secondsOfDay) {
+        int hours = static_cast<int>(secondsOfDay / 3600) % 24;
+        int minutes = static_cast<int>(secondsOfDay / 60) % 60;
+        int seconds = static_cast<int>(secondsOfDay) % 60;
+
+        return fixStringLength(std::to_string(hours), 2) + ":" +
+               fixStringLength(std::to_string(minutes), 2) + ":" +
+               fixStringLength(std::to_string(seconds), 2);
+    }
+
+    std::string formatSecondsAsMinSec(float totalSeconds) {
+        int seconds = static_cast<int>(std::floor(totalSeconds));
+        int mins = seconds / 60;
+        int secs = seconds % 60;
+
+        return fixStringLength(std::to_string(mins), 2) + ":" +
+               fixStringLength(std::to_string(secs), 2);
     }
 
     std::vector<uint8_t> encodeString(int numSegments, const std::string &str) {

--- a/src/include/utils/segment-display.h
+++ b/src/include/utils/segment-display.h
@@ -24,6 +24,16 @@ namespace SegmentDisplay {
     // Fix string length with leading zeros
     std::string fixStringLength(const std::string &value, int length, char fillChar = '0');
 
+    // Formats a day-of-year (1-based, e.g. sim/time/local_date_days + 1) as
+    // "MM:DD:YY" using the current calendar year.
+    std::string formatDateFromDayOfYear(int dayOfYear);
+
+    // Formats a seconds-since-midnight value (e.g. sim/time/zulu_time_sec) as "HH:MM:SS"
+    std::string formatTimeFromSecondsOfDay(double secondsOfDay);
+
+    // Formats an elapsed-seconds value (e.g. a chronograph reading) as "MM:SS"
+    std::string formatSecondsAsMinSec(float totalSeconds);
+
     // Swap nibbles in a byte
     uint8_t swapNibbles(uint8_t value);
 


### PR DESCRIPTION
Day-of-year->date, seconds-of-day->HH:MM:SS, and seconds->MM:SS were each copy-pasted across pa28/toliss/rotatemd11 AGP profiles. These are now helpers.