### PR TITLE
Unswap LNAV and VNAV functionality on FCU with Zibo

### DIFF
--- a/src/include/products/fcu-efis/profiles/zibo-fcu-efis-profile.cpp
+++ b/src/include/products/fcu-efis/profiles/zibo-fcu-efis-profile.cpp
@@ -184,13 +184,13 @@ const std::unordered_map<uint16_t, FCUEfisButtonDef> &ZiboFCUEfisProfile::button
         // Heading encoder
         {13, {"HDG DEC", "sim/autopilot/heading_down"}},
         {14, {"HDG INC", "sim/autopilot/heading_up"}},
-        {15, {"HDG PUSH", "laminar/B738/autopilot/vnav_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
+        {15, {"HDG PUSH", "laminar/B738/autopilot/lnav_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
         {16, {"HDG PULL", "laminar/B738/autopilot/hdg_sel_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
 
         // Altitude encoder - routed through custom_altitude so the 100/1000 switch controls the step
         {17, {"ALT DEC", "custom_altitude", FCUEfisDatarefType::EXECUTE_CMD_ONCE, -1.0}},
         {18, {"ALT INC", "custom_altitude", FCUEfisDatarefType::EXECUTE_CMD_ONCE, 1.0}},
-        {19, {"ALT PUSH", "laminar/B738/autopilot/lnav_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
+        {19, {"ALT PUSH", "laminar/B738/autopilot/vnav_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
         {20, {"ALT PULL", "laminar/B738/autopilot/lvl_chg_press", FCUEfisDatarefType::EXECUTE_CMD_ONCE}},
 
         // Vertical Speed encoder


### PR DESCRIPTION
<!--
Please read CONTRIBUTING.md first. Two things in short:
- Refactors on their own are not accepted, only fixes and new functionality.
- Anything touching a device protocol, display, LED or button must be tested on the physical device.
-->

## What does this fix?

<!-- The behaviour you saw on hardware or in the sim, and what it should be instead. If this does not fix anything, please open an issue instead of a pull request. -->
Currently, pushing the heading selector on the FCU activates VNAV (and lights up the managed dot on the altitude window) instead of LNAV on the Zibo 737. Likewise, pushing the altitude selector activates LNAV (lighting up the managed dot on the heading window) instead of VNAV. This PR unswaps the LNAV/VNAV datarefs to fix this behavior.

## How did you test it?

- Device: FCU
- Aircraft: Zibo 737 v4.05.35
- X-Plane version: 12
- Platform (macOS / Windows / Linux): Linux

<!-- If you could not test on hardware, say so here. -->
