### PR TITLE
fix: Light the FF757/767 CDU MSG annunciator

### DIFF
--- a/src/include/products/fmc/profiles/ff767-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/ff767-fmc-profile.cpp
@@ -28,6 +28,13 @@ FlightFactor767FMCProfile::FlightFactor767FMCProfile(ProductFMC *product) : FMCA
         Dataref::getInstance()->executeChangedCallbacksForDataref("sim/cockpit/electrical/instrument_brightness");
     },
         this);
+
+    Dataref::getInstance()->monitorExistingDataref<int>("757Avionics/fms/warn_flags", [product](int flags) {
+        bool message = (static_cast<uint32_t>(flags) & FlightFactor767FMCProfile::FmsWarnFlagMsg) != 0;
+        product->setLedBrightness(FMCLed::PFP_MSG, message ? 1 : 0);
+        product->setLedBrightness(FMCLed::MCDU_MCDU, message ? 1 : 0);
+    },
+        this);
 }
 
 bool FlightFactor767FMCProfile::IsEligible() {

--- a/src/include/products/fmc/profiles/ff767-fmc-profile.h
+++ b/src/include/products/fmc/profiles/ff767-fmc-profile.h
@@ -3,6 +3,7 @@
 
 #include "fmc-aircraft-profile.h"
 
+#include <cstdint>
 #include <regex>
 
 class FlightFactor767FMCProfile : public FMCAircraftProfile {
@@ -17,6 +18,7 @@ class FlightFactor767FMCProfile : public FMCAircraftProfile {
         static bool IsEligible();
 
         static constexpr uint16_t DataLength = 14 * 24; // 336 letters (14 lines x 24 chars)
+        static constexpr uint32_t FmsWarnFlagMsg = 1u << 3;
         const std::vector<std::string> &displayDatarefs() const override;
         const std::vector<FMCButtonDef> &buttonDefs() const override;
         const std::unordered_map<FMCKey, const FMCButtonDef *> &buttonKeyMap() const override;


### PR DESCRIPTION
## What does this fix?

The profile never drove any of the CDU annunciators, so the MSG light stayed dark on the PFP and the MCDU while the aircraft's own CDU showed the message.

The aircraft does not publish a dedicated lamp dataref. The FMS exposes its annunciators as bits in 757Avionics/fms/warn_flags, where bit 3 tracks MSG. Drive both the PFP and MCDU lamps from it; setLedBrightness already filters the set that does not apply to the attached hardware.

Tested on a PFP 3N with the FlightFactor 767 in X-Plane 12.

## How did you test it?

- Device: PFP 3N
- Aircraft: FF767 and FF757
- X-Plane version: 12
- Platform (macOS / Windows / Linux): Windows