### PR TITLE
fix: Use the FF757/767 CDU brightness rotary for the FMC brightness keys

### DIFF
--- a/src/include/products/fmc/profiles/ff767-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/ff767-fmc-profile.cpp
@@ -58,6 +58,7 @@ const std::vector<std::string> &FlightFactor767FMCProfile::displayDatarefs() con
 
 const std::vector<FMCButtonDef> &FlightFactor767FMCProfile::buttonDefs() const {
     const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "CDU" : "CDU2";
+    const std::string brtSide = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "L" : "R";
     static std::unordered_map<FMCDeviceVariant, std::vector<FMCButtonDef>> cache;
 
     return cache.try_emplace(product->deviceVariant,
@@ -79,8 +80,8 @@ const std::vector<FMCButtonDef> &FlightFactor767FMCProfile::buttonDefs() const {
                         {FMCKey::PFP3_CLB, "757Avionics/" + cdu + "/clb", FMCDatarefType::SET_VALUE_PHASED},
                         {FMCKey::PFP3_CRZ, "757Avionics/" + cdu + "/crz", FMCDatarefType::SET_VALUE_PHASED},
                         {FMCKey::PFP3_DES, "757Avionics/" + cdu + "/des", FMCDatarefType::SET_VALUE_PHASED},
-                        {FMCKey::BRIGHTNESS_DOWN, "ixeg/733/rheostats/light_fmc_pt_act", FMCDatarefType::ADJUST_VALUE, -0.1},
-                        {FMCKey::BRIGHTNESS_UP, "ixeg/733/rheostats/light_fmc_pt_act", FMCDatarefType::ADJUST_VALUE, 0.1},
+                        {FMCKey::BRIGHTNESS_DOWN, "1-sim/CDU/" + brtSide + "/CDUbrtRotary", FMCDatarefType::ADJUST_VALUE, -0.1},
+                        {FMCKey::BRIGHTNESS_UP, "1-sim/CDU/" + brtSide + "/CDUbrtRotary", FMCDatarefType::ADJUST_VALUE, 0.1},
                         {FMCKey::MENU, "757Avionics/" + cdu + "/mcdu_menu", FMCDatarefType::SET_VALUE_PHASED},
                         {std::vector<FMCKey>{FMCKey::PFP_LEGS, FMCKey::MCDU_FPLN, FMCKey::MCDU_DIR}, "757Avionics/" + cdu + "/legs", FMCDatarefType::SET_VALUE_PHASED},
                         {std::vector<FMCKey>{FMCKey::PFP_DEP_ARR, FMCKey::MCDU_AIRPORT}, "757Avionics/" + cdu + "/dep_arr", FMCDatarefType::SET_VALUE_PHASED},
@@ -268,9 +269,13 @@ void FlightFactor767FMCProfile::buttonPressed(const FMCButtonDef *button, XPLMCo
         }
 
         datarefManager->set<double>(button->dataref.c_str(), phase == xplm_CommandBegin ? value : 0.0);
-    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::ADJUST_VALUE) {
+    } else if (button->datarefType == FMCDatarefType::ADJUST_VALUE) {
+        if (phase != xplm_CommandBegin) {
+            return;
+        }
+
         double currentValue = datarefManager->get<double>(button->dataref.c_str());
-        datarefManager->set<double>(button->dataref.c_str(), currentValue + button->value);
+        datarefManager->set<double>(button->dataref.c_str(), std::clamp(currentValue + button->value, 0.0, FlightFactor767FMCProfile::BrightnessMax));
     } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::EXECUTE_MULTIPLE_CMD_ONCE) {
         std::stringstream ss(button->dataref);
         std::string item;

--- a/src/include/products/fmc/profiles/ff767-fmc-profile.h
+++ b/src/include/products/fmc/profiles/ff767-fmc-profile.h
@@ -17,6 +17,7 @@ class FlightFactor767FMCProfile : public FMCAircraftProfile {
         static bool IsEligible();
 
         static constexpr uint16_t DataLength = 14 * 24; // 336 letters (14 lines x 24 chars)
+        static constexpr double BrightnessMax = 1.0;
         const std::vector<std::string> &displayDatarefs() const override;
         const std::vector<FMCButtonDef> &buttonDefs() const override;
         const std::unordered_map<FMCKey, const FMCButtonDef *> &buttonKeyMap() const override;


### PR DESCRIPTION
## What does this fix?

The FlightFactor 767 FMC profile pointed the brightness keys at ixeg/733/rheostats/light_fmc_pt_act, an IXEG 737 dataref that does not exist on the FlightFactor 757 or 767. ADJUST_VALUE silently no-ops when the dataref is missing, so the keys did nothing on either aircraft.

ADJUST_VALUE only acts on the press, but it was matched with the phase folded into the branch condition, so the release fell through to the executeCommand default and logged "Command not found" for the dataref on every keypress. Match on the type and return on the other phases.

## How did you test it?

- Device: PFP 3N
- Aircraft: FF 767 and FF757
- X-Plane version: 12
- Platform (macOS / Windows / Linux): Windows