### PR TITLE
Map the MCDU AIRPORT button for the DEP / ARR button of the hotstart challenger 650.

### DIFF
--- a/src/include/products/fmc/profiles/cl650-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/cl650-fmc-profile.cpp
@@ -123,7 +123,7 @@ const std::vector<FMCButtonDef> &CL650FMCProfile::buttonDefs() const {
             {std::vector<FMCKey>{FMCKey::MCDU_SEC_FPLN, FMCKey::PFP_ROUTE}, "CL650/CDU/" + cdu + "/fpln", FMCDatarefType::SET_VALUE, 1.0},
             {std::vector<FMCKey>{FMCKey::MCDU_RAD_NAV, FMCKey::PFP4_NAV_RAD, FMCKey::PFP7_NAV_RAD}, "CL650/CDU/" + cdu + "/tun", FMCDatarefType::SET_VALUE, 1.0},
             {std::vector<FMCKey>{FMCKey::PFP_LEGS, FMCKey::MCDU_FPLN}, "CL650/CDU/" + cdu + "/legs", FMCDatarefType::SET_VALUE, 1.0},
-            {FMCKey::PFP_DEP_ARR, "CL650/CDU/" + cdu + "/dep_arr", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PFP_DEP_ARR, FMCKey::MCDU_AIRPORT}, "CL650/CDU/" + cdu + "/dep_arr", FMCDatarefType::SET_VALUE, 1.0},
             {std::vector<FMCKey>{FMCKey::PFP_EXEC, FMCKey::MCDU_EMPTY_TOP_RIGHT}, "CL650/CDU/" + cdu + "/exec", FMCDatarefType::SET_VALUE, 1.0},
             {std::vector<FMCKey>{FMCKey::CLR, FMCKey::PFP_DEL}, "CL650/CDU/" + cdu + "/clr_del", FMCDatarefType::SET_VALUE, 1.0},
             {FMCKey::MENU, "CL650/CDU/" + cdu + "/dspl_menu", FMCDatarefType::SET_VALUE, 1.0},


### PR DESCRIPTION
<!--
Please read CONTRIBUTING.md first. Two things in short:
- Refactors on their own are not accepted, only fixes and new functionality.
- Anything touching a device protocol, display, LED or button must be tested on the physical device.
-->

## What does this fix?

Can't use the the DEP ARR button on the Challenger 650 with the MCDU. I suggest to use the unused AIRPORT button on the MCDU for this Challenger 650 FMS page.

## How did you test it?

- Device: WINCTRL MCDU
- Aircraft: Hotstart CL650
- X-Plane version: 12
- Platform (macOS / Windows / Linux): Win11

<!-- If you could not test on hardware, say so here. -->

## References

<!-- If you make a claim about how the code behaves, point at the file and line that supports it. -->
